### PR TITLE
fix: proxy instructions, yarn troubleshooting

### DIFF
--- a/instructions/docs/before-academy/before-academy.md
+++ b/instructions/docs/before-academy/before-academy.md
@@ -59,6 +59,9 @@ npm install --global yarn
 
 See [yarn installation documentation](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) for more details.
 
+:::note[Node versions]
+If using yarn for the first time, you may need to add the install location to your local path (see details here: https://classic.yarnpkg.com/lang/en/docs/cli/global/)
+:::
 
 
 ### d2

--- a/instructions/docs/resources/DEBUG.md
+++ b/instructions/docs/resources/DEBUG.md
@@ -3,13 +3,9 @@ title: Debugging
 sidebar_position: 10
 ---
 
-:::danger[ToDo]
-- Are all these instructions still applicable?
-:::
-
 # Live instance debugging
 
-If you can't login to the server: https://academy.demos.dhis2.org/web-app/ or you get some Cross-Origin Resource Sharing (CORs) policy issues in the DevTools Console when trying to connect to your application, please try the following troubleshooting steps:
+If you can't login to the server: https://dev.im.dhis2.org/academy-web or you get some Cross-Origin Resource Sharing (CORs) policy issues in the DevTools Console when trying to connect to your application, please try the following troubleshooting steps:
 
 ## CORs whitelist
 
@@ -35,7 +31,7 @@ Due to the default SameSite cookie behaviour in Chrome being impossible to overr
 This starts a proxy-server in the background, re-routing all requests from your localhost to the specified DHIS2-instance, circumventing the SameSite behaviour.
 
 ```
-yarn start --proxy https://academy.demos.dhis2.org/web-app --proxyPort 8082
+yarn start --proxy https://dev.im.dhis2.org/academy-web --proxyPort 8082
 ```
 
 _Note_: Make sure to set the Server-field when logging into your app to `http://localhost:8082`.

--- a/instructions/docs/resources/set_up_fork.md
+++ b/instructions/docs/resources/set_up_fork.md
@@ -62,7 +62,7 @@ You are now ready to start your application locally!
 Run `yarn start` - This will run the app in the development mode.
 
 ```sh
- yarn start
+ yarn start --proxy https://dev.im.dhis2.org/academy-web --proxyPort 8082
 ```
 
 From the browser, go to [http://localhost:3000](http://localhost:3000). You will see the following page:
@@ -70,7 +70,7 @@ From the browser, go to [http://localhost:3000](http://localhost:3000). You will
 ![](../assets/new-app-login-page.png)
 
 Before you sign in, you need to log in to the DHIS2 instance which will be your **server**:
-  - Go to: https://dev.im.dhis2.org/academy-web
+  - Go to: http://localhost:8082
   - You will see this page:
 ![](../assets/image-of-login.png)
   - Sign in as username: `admin` and password: `district`
@@ -78,7 +78,7 @@ Before you sign in, you need to log in to the DHIS2 instance which will be your 
 * Finally, go back to [http://localhost:3000](http://localhost:3000) and enter the following:
 
 ```
-server: https://dev.im.dhis2.org/academy-web
+server: http://localhost:8082
 username: admin
 password: district
 ```


### PR DESCRIPTION
Some day 1 documentation updates:
- consistent references to academy web site
- proxy instruction updates
- yarn troubleshooting